### PR TITLE
feat: brand-first landing with carousel and trust rows

### DIFF
--- a/components/BeforeAfterCarousel.tsx
+++ b/components/BeforeAfterCarousel.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from 'react';
+
+interface BeforeAfterItem {
+  before: string;
+  after: string;
+  label?: string;
+}
+
+interface CarouselProps {
+  items: BeforeAfterItem[];
+}
+
+const BeforeAfterCarousel: React.FC<CarouselProps> = ({ items }) => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (items.length === 0) return;
+    const id = setInterval(() => {
+      setIndex((prev) => (prev + 1) % items.length);
+    }, 5000);
+    return () => clearInterval(id);
+  }, [items.length]);
+
+  const prev = () => {
+    setIndex((prev) => (prev - 1 + items.length) % items.length);
+  };
+
+  const next = () => {
+    setIndex((prev) => (prev + 1) % items.length);
+  };
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="relative w-full h-full overflow-hidden">
+      <div
+        className="flex transition-transform duration-700 h-full"
+        style={{ transform: `translateX(-${index * 100}%)`, width: `${items.length * 100}%` }}
+      >
+        {items.map((item, i) => (
+          <div key={i} className="w-full flex-shrink-0 flex gap-2 sm:gap-4 p-4">
+            <div className="w-1/2 rounded-lg overflow-hidden bg-gray-700 flex items-center justify-center">
+              {item.before ? (
+                <img src={item.before} alt={item.label ? `${item.label} before` : `before ${i + 1}`} className="w-full h-full object-cover" />
+              ) : (
+                <span className="text-gray-400">Before</span>
+              )}
+            </div>
+            <div className="w-1/2 rounded-lg overflow-hidden bg-gray-700 flex items-center justify-center">
+              {item.after ? (
+                <img src={item.after} alt={item.label ? `${item.label} after` : `after ${i + 1}`} className="w-full h-full object-cover" />
+              ) : (
+                <span className="text-gray-400">After</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <button
+        onClick={prev}
+        className="absolute left-2 top-1/2 -translate-y-1/2 bg-gray-900/50 hover:bg-gray-900/80 text-white rounded-full p-2"
+        aria-label="Previous"
+      >
+        &#10094;
+      </button>
+      <button
+        onClick={next}
+        className="absolute right-2 top-1/2 -translate-y-1/2 bg-gray-900/50 hover:bg-gray-900/80 text-white rounded-full p-2"
+        aria-label="Next"
+      >
+        &#10095;
+      </button>
+    </div>
+  );
+};
+
+export default BeforeAfterCarousel;

--- a/components/LoginScreen.tsx
+++ b/components/LoginScreen.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { login } from '../services/geminiService';
-import { GoogleIcon } from './icons';
+import BeforeAfterCarousel from './BeforeAfterCarousel';
+import TrustRow from './TrustRow';
+import OutcomeRow from './OutcomeRow';
 
 // TypeScript declaration for the google object from the GSI script
 declare const google: any;
@@ -12,6 +14,15 @@ interface LoginScreenProps {
 const LoginScreen: React.FC<LoginScreenProps> = ({ onLogin }) => {
   const signInButton = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const carouselItems = [
+    { before: '', after: '', label: 'Example 1' },
+    { before: '', after: '', label: 'Example 2' },
+    { before: '', after: '', label: 'Example 3' },
+    { before: '', after: '', label: 'Example 4' },
+    { before: '', after: '', label: 'Example 5' },
+    { before: '', after: '', label: 'Example 6' }
+  ];
 
   useEffect(() => {
     // Check if the google object is available from the script loaded in index.html
@@ -42,31 +53,34 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ onLogin }) => {
   }, [onLogin]);
 
   return (
-    <div className="min-h-screen bg-gray-900 text-white font-sans flex flex-col items-center justify-center p-4 relative overflow-hidden">
-      <div className="absolute top-0 left-0 w-full h-full bg-gradient-to-br from-gray-900 via-gray-900 to-fuchsia-900/40 z-0"></div>
-      <div className="w-full max-w-md mx-auto z-10 text-center">
-        <header className="my-8">
-            <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-fuchsia-500 to-cyan-400">
-                Couch Influencer
-            </h1>
-            <p className="mt-3 text-lg sm:text-xl text-gray-400 max-w-2xl mx-auto">
-                Create your dream travel photos without leaving home.
-            </p>
-        </header>
-
-        <main className="bg-gray-800/50 backdrop-blur-xl border border-gray-700 rounded-2xl shadow-2xl shadow-black/30 p-8 sm:p-10">
+    <div className="min-h-screen bg-gray-900 text-white font-sans flex flex-col overflow-hidden">
+      <section className="relative w-full h-[60vh] sm:h-[70vh]">
+        <BeforeAfterCarousel items={carouselItems} />
+        <div className="absolute inset-0 bg-gradient-to-br from-gray-900 via-gray-900 to-fuchsia-900/60"></div>
+        <div className="absolute inset-0 flex flex-col items-center justify-center text-center p-4">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-fuchsia-500 to-cyan-400">
+            Couch Influencer
+          </h1>
+          <p className="mt-3 text-lg sm:text-xl text-gray-300 max-w-2xl mx-auto">
+            Create your dream travel photos without leaving home.
+          </p>
+          <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700 rounded-2xl shadow-2xl shadow-black/30 p-8 sm:p-10 mt-8 w-full max-w-md">
             <h2 className="text-2xl font-semibold text-gray-100 mb-4">Welcome Back!</h2>
             <p className="text-gray-400 mb-8">
-                Ready to explore the world from your couch? Sign in to continue your journey.
+              Ready to explore the world from your couch? Sign in to continue your journey.
             </p>
-            {error && <div className="text-center bg-red-500/20 border border-red-500 text-red-300 p-3 rounded-lg mb-4">{error}</div>}
-            {/* The Google Sign-In button will be rendered into this div */}
+            {error && (
+              <div className="text-center bg-red-500/20 border border-red-500 text-red-300 p-3 rounded-lg mb-4">
+                {error}
+              </div>
+            )}
             <div ref={signInButton} className="flex justify-center"></div>
-        </main>
-        <footer className="mt-12 text-gray-500">
-            <p>Powered by Gemini AI</p>
-        </footer>
-      </div>
+          </div>
+        </div>
+      </section>
+      <TrustRow />
+      <OutcomeRow />
+      <footer className="text-center py-8 text-gray-500">Powered by Gemini AI</footer>
     </div>
   );
 };

--- a/components/OutcomeRow.tsx
+++ b/components/OutcomeRow.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface OutcomeCategory {
+  title: string;
+  images: string[];
+}
+
+const OutcomeRow: React.FC = () => {
+  const categories: OutcomeCategory[] = [
+    { title: 'Creators', images: ['', '', ''] },
+    { title: 'Shops', images: ['', '', ''] },
+    { title: 'Travel', images: ['', '', ''] },
+    { title: 'Dating', images: ['', '', ''] },
+  ];
+
+  return (
+    <section className="py-12 bg-gray-900 text-white">
+      <div className="max-w-5xl mx-auto px-4">
+        <h2 className="text-2xl font-bold text-center mb-8">Made for:</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8">
+          {categories.map((cat) => (
+            <div key={cat.title} className="text-center">
+              <h3 className="text-lg font-semibold mb-3">{cat.title}</h3>
+              <div className="grid grid-cols-3 gap-2">
+                {cat.images.map((src, i) => (
+                  <div
+                    key={i}
+                    className="aspect-square bg-gray-700 rounded-md flex items-center justify-center text-gray-500 text-xs"
+                  >
+                    {src ? (
+                      <img src={src} alt={`${cat.title} ${i + 1}`} className="w-full h-full object-cover rounded-md" />
+                    ) : (
+                      <span>img</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default OutcomeRow;

--- a/components/TrustRow.tsx
+++ b/components/TrustRow.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { LockClosedIcon, SparklesIcon } from './icons';
+
+const TrustRow: React.FC = () => {
+  return (
+    <section className="bg-gray-800 text-gray-200 py-6">
+      <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-center gap-8 px-4 text-sm sm:text-base">
+        <div className="flex items-center gap-3">
+          <LockClosedIcon className="w-6 h-6 text-fuchsia-400" />
+          <span>Selfies auto-delete / not used for training</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <SparklesIcon className="w-6 h-6 text-fuchsia-400" />
+          <span>Explicit AI disclosure on every image</span>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TrustRow;

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -43,6 +43,12 @@ export const QuestionMarkCircleIcon = ({ className }: { className?: string }) =>
     </svg>
 );
 
+export const LockClosedIcon = ({ className }: { className?: string }) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V7.5a4.5 4.5 0 00-9 0v3m10.5 0H6a2 2 0 00-2 2v6a2 2 0 002 2h12a2 2 0 002-2v-6a2 2 0 00-2-2z" />
+    </svg>
+);
+
 export const CreditCardIcon = ({ className }: { className?: string }) => (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 21z" />


### PR DESCRIPTION
## Summary
- add reusable before/after carousel component
- overlay login on carousel and add trust & outcome sections
- include lock icon for safety messaging

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8081d9ec8832d9d5e172f741ef064